### PR TITLE
Fixed link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Web Security Quiz
 
-[Test your Web Security Knowledge](websecurity.firebaseapp.com) with Questions from the [OWASP Top 10 Threats and Mitigations Exam](https://www.owasp.org/index.php/OWASP_Exams_Project).
+[Test your Web Security Knowledge](https://websecurity.firebaseapp.com) with Questions from the [OWASP Top 10 Threats and Mitigations Exam](https://www.owasp.org/index.php/OWASP_Exams_Project).
 
 
 Built with Polymer 1.0. Based on the [Polymer Starter Kit](https://github.com/PolymerElements/polymer-starter-kit) (if you want to run the project, follow the setup instructions of the Starter Kit).


### PR DESCRIPTION
Fixed link which was incorrectly pointing to `https://github.com/RobinLinus/websecurity-quiz/blob/master/websecurity.firebaseapp.com`